### PR TITLE
Handling of forms with dynamic values

### DIFF
--- a/bundle/BDGuzzleSiteAuthenticatorBundle.php
+++ b/bundle/BDGuzzleSiteAuthenticatorBundle.php
@@ -2,8 +2,16 @@
 
 namespace BD\GuzzleSiteAuthenticatorBundle;
 
+use BD\GuzzleSiteAuthenticatorBundle\DependencyInjection\CompilerPass\RegisterWallabagGuzzleSubscribersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class BDGuzzleSiteAuthenticatorBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new RegisterWallabagGuzzleSubscribersPass());
+    }
 }

--- a/bundle/DependencyInjection/CompilerPass/RegisterWallabagGuzzleSubscribersPass.php
+++ b/bundle/DependencyInjection/CompilerPass/RegisterWallabagGuzzleSubscribersPass.php
@@ -18,6 +18,8 @@ class RegisterWallabagGuzzleSubscribersPass implements CompilerPassInterface
         }
 
         $definition = $container->getDefinition('wallabag_core.guzzle.http_client_factory');
+
+        // manually add subsribers for some websites
         $definition->addMethodCall(
             'addSubscriber', [
                 new Reference('bd_guzzle_site_authenticator.monde_diplomatique_uri_fix_subscriber'),

--- a/bundle/DependencyInjection/CompilerPass/RegisterWallabagGuzzleSubscribersPass.php
+++ b/bundle/DependencyInjection/CompilerPass/RegisterWallabagGuzzleSubscribersPass.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace BD\GuzzleSiteAuthenticatorBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterWallabagGuzzleSubscribersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('wallabag_core.guzzle.http_client_factory')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('wallabag_core.guzzle.http_client_factory');
+        $definition->addMethodCall(
+            "addSubscriber", [
+                new Reference('bd_guzzle_site_authenticator.monde_diplomatique_uri_fix_subscriber'),
+            ]
+        );
+    }
+}

--- a/bundle/DependencyInjection/CompilerPass/RegisterWallabagGuzzleSubscribersPass.php
+++ b/bundle/DependencyInjection/CompilerPass/RegisterWallabagGuzzleSubscribersPass.php
@@ -2,6 +2,7 @@
 /**
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace BD\GuzzleSiteAuthenticatorBundle\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -18,7 +19,7 @@ class RegisterWallabagGuzzleSubscribersPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('wallabag_core.guzzle.http_client_factory');
         $definition->addMethodCall(
-            "addSubscriber", [
+            'addSubscriber', [
                 new Reference('bd_guzzle_site_authenticator.monde_diplomatique_uri_fix_subscriber'),
             ]
         );

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -18,3 +18,6 @@ services:
         class: BD\GuzzleSiteAuthenticator\SiteConfig\ArraySiteConfigBuilder
         arguments:
             - "%bd_guzzle_site_authenticator.site_config%"
+
+    bd_guzzle_site_authenticator.monde_diplomatique_uri_fix_subscriber:
+        class: BD\GuzzleSiteAuthenticator\Guzzle\FixupMondeDiplomatiqueUriSubscriber

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require-dev": {
-        "phpspec/phpspec": "^2.4",
+        "phpspec/phpspec": "^3.0",
         "friendsofphp/php-cs-fixer": "~2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "A guzzle plugin that adds, if necessary, authentication data to requests. Uses credentials and cookies, with login requests to the sites.",
     "license": "MIT",
     "require": {
-        "guzzlehttp/guzzle": "^5.2.0"
+        "guzzlehttp/guzzle": "^5.2.0",
+        "symfony/expression-language": "^3.2"
     },
     "authors": [
         {

--- a/lib/Authenticator/LoginFormAuthenticator.php
+++ b/lib/Authenticator/LoginFormAuthenticator.php
@@ -2,8 +2,8 @@
 
 namespace BD\GuzzleSiteAuthenticator\Authenticator;
 
-use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfig;
 use BD\GuzzleSiteAuthenticator\ExpressionLanguage\AuthenticatorProvider;
+use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfig;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Cookie\CookieJar;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
@@ -94,7 +94,7 @@ class LoginFormAuthenticator implements Authenticator
                 $fieldValue = $expressionLanguage->evaluate(
                     substr($fieldValue, 2),
                     [
-                        'config' => $this->siteConfig
+                        'config' => $this->siteConfig,
                     ]
                 );
             }

--- a/lib/Authenticator/LoginFormAuthenticator.php
+++ b/lib/Authenticator/LoginFormAuthenticator.php
@@ -87,8 +87,7 @@ class LoginFormAuthenticator implements Authenticator
     {
         $extraFields = [];
 
-        foreach ($this->siteConfig->getExtraFields() as $extraField) {
-            list($fieldName, $fieldValue) = explode('=', $extraField, 2);
+        foreach ($this->siteConfig->getExtraFields() as $fieldName => $fieldValue) {
             if (substr($fieldValue, 0, 2) === '@=') {
                 $expressionLanguage = $this->getExpressionLanguage($guzzle);
                 $fieldValue = $expressionLanguage->evaluate(
@@ -98,6 +97,7 @@ class LoginFormAuthenticator implements Authenticator
                     ]
                 );
             }
+
             $extraFields[$fieldName] = $fieldValue;
         }
 

--- a/lib/ExpressionLanguage/AuthenticatorProvider.php
+++ b/lib/ExpressionLanguage/AuthenticatorProvider.php
@@ -48,13 +48,16 @@ class AuthenticatorProvider implements ExpressionFunctionProviderInterface
                 throw new Exception('Not supported');
             },
             function (array $arguments, $xpathQuery, $html) {
-                libxml_use_internal_errors(true);
+                $useInternalErrors = libxml_use_internal_errors(true);
+
                 $doc = new \DOMDocument();
                 $doc->loadHTML($html, LIBXML_NOCDATA | LIBXML_NOWARNING | LIBXML_NOERROR);
 
                 $xpath = new \DOMXPath($doc);
                 $domNodeList = $xpath->query($xpathQuery);
                 $domNode = $domNodeList->item(0);
+
+                libxml_use_internal_errors($useInternalErrors);
 
                 return $domNode->attributes->getNamedItem('value')->nodeValue;
             }

--- a/lib/ExpressionLanguage/AuthenticatorProvider.php
+++ b/lib/ExpressionLanguage/AuthenticatorProvider.php
@@ -32,7 +32,7 @@ class AuthenticatorProvider implements ExpressionFunctionProviderInterface
         return new ExpressionFunction(
             'request_html',
             function () {
-                throw new Exception("Not supported");
+                throw new Exception('Not supported');
             },
             function (array $arguments, $uri, array $options = []) {
                 return $this->guzzle->get($uri, $options)->getBody();
@@ -45,11 +45,12 @@ class AuthenticatorProvider implements ExpressionFunctionProviderInterface
         return new ExpressionFunction(
             'xpath',
             function () {
-                throw new Exception("Not supported");
+                throw new Exception('Not supported');
             },
             function (array $arguments, $xpathQuery, $html) {
-                $doc = new \DOMDocument;
-                @$doc->loadHTML($html, LIBXML_NOCDATA | LIBXML_NOWARNING | LIBXML_NOERROR);
+                libxml_use_internal_errors(true);
+                $doc = new \DOMDocument();
+                $doc->loadHTML($html, LIBXML_NOCDATA | LIBXML_NOWARNING | LIBXML_NOERROR);
 
                 $xpath = new \DOMXPath($doc);
                 $domNodeList = $xpath->query($xpathQuery);

--- a/lib/ExpressionLanguage/AuthenticatorProvider.php
+++ b/lib/ExpressionLanguage/AuthenticatorProvider.php
@@ -22,20 +22,20 @@ class AuthenticatorProvider implements ExpressionFunctionProviderInterface
     public function getFunctions()
     {
         return [
-            $this->getRequestFunction(),
+            $this->getRequestHtmlFunction(),
             $this->getXpathFunction(),
         ];
     }
 
-    private function getRequestFunction()
+    private function getRequestHtmlFunction()
     {
         return new ExpressionFunction(
             'request_html',
             function () {
                 throw new Exception("Not supported");
             },
-            function (array $arguments, $uri) {
-                return $this->guzzle->get($uri)->getBody();
+            function (array $arguments, $uri, array $options = []) {
+                return $this->guzzle->get($uri, $options)->getBody();
             }
         );
     }

--- a/lib/ExpressionLanguage/AuthenticatorProvider.php
+++ b/lib/ExpressionLanguage/AuthenticatorProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace BD\GuzzleSiteAuthenticator\ExpressionLanguage;
+
+use Exception;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+class AuthenticatorProvider implements ExpressionFunctionProviderInterface
+{
+    /**
+     * @var ClientInterface
+     */
+    private $guzzle;
+
+    public function __construct(ClientInterface $guzzle)
+    {
+        $this->guzzle = $guzzle;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            $this->getRequestFunction(),
+            $this->getXpathFunction(),
+        ];
+    }
+
+    private function getRequestFunction()
+    {
+        return new ExpressionFunction(
+            'request_html',
+            function () {
+                throw new Exception("Not supported");
+            },
+            function (array $arguments, $uri) {
+                return $this->guzzle->get($uri)->getBody();
+            }
+        );
+    }
+
+    private function getXpathFunction()
+    {
+        return new ExpressionFunction(
+            'xpath',
+            function () {
+                throw new Exception("Not supported");
+            },
+            function (array $arguments, $xpathQuery, $html) {
+                $doc = new \DOMDocument;
+                @$doc->loadHTML($html, LIBXML_NOCDATA | LIBXML_NOWARNING | LIBXML_NOERROR);
+
+                $xpath = new \DOMXPath($doc);
+                $domNodeList = $xpath->query($xpathQuery);
+                $domNode = $domNodeList->item(0);
+
+                return $domNode->attributes->getNamedItem('value')->nodeValue;
+            }
+        );
+    }
+}

--- a/lib/Guzzle/AuthenticatorSubscriber.php
+++ b/lib/Guzzle/AuthenticatorSubscriber.php
@@ -71,8 +71,9 @@ class AuthenticatorSubscriber implements SubscriberInterface
         }
 
         $authenticator = $this->authenticatorFactory->buildFromSiteConfig($config);
+        $isLoginRequired = $authenticator->isLoginRequired($event->getResponse()->getBody());
 
-        if ($authenticator->isLoginRequired($event->getResponse()->getBody()) && self::$retries < self::MAX_RETRIES) {
+        if ($isLoginRequired && self::$retries < self::MAX_RETRIES) {
             $client = $event->getClient();
 
             $emitter = $client->getEmitter();

--- a/lib/Guzzle/FixupMondeDiplomatiqueUriSubscriber.php
+++ b/lib/Guzzle/FixupMondeDiplomatiqueUriSubscriber.php
@@ -2,10 +2,11 @@
 /**
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace BD\GuzzleSiteAuthenticator\Guzzle;
 
-use GuzzleHttp\Event\SubscriberInterface;
 use GuzzleHttp\Event\CompleteEvent;
+use GuzzleHttp\Event\SubscriberInterface;
 
 /**
  * Fixes url encoding of a parameter guzzle fails with.
@@ -30,6 +31,6 @@ class FixupMondeDiplomatiqueUriSubscriber implements SubscriberInterface
             return;
         }
 
-        $response->setHeader('Location',  str_replace($badParameter, urlencode($badParameter), $uri));
+        $response->setHeader('Location', str_replace($badParameter, urlencode($badParameter), $uri));
     }
 }

--- a/lib/Guzzle/FixupMondeDiplomatiqueUriSubscriber.php
+++ b/lib/Guzzle/FixupMondeDiplomatiqueUriSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace BD\GuzzleSiteAuthenticator\Guzzle;
+
+use GuzzleHttp\Event\SubscriberInterface;
+use GuzzleHttp\Event\CompleteEvent;
+
+/**
+ * Fixes url encoding of a parameter guzzle fails with.
+ */
+class FixupMondeDiplomatiqueUriSubscriber implements SubscriberInterface
+{
+    public function getEvents()
+    {
+        return ['complete' => [['fixUri', 500]]];
+    }
+
+    public function fixUri(CompleteEvent $event)
+    {
+        $response = $event->getResponse();
+
+        if (!$response->hasHeader('Location')) {
+            return;
+        }
+
+        $uri = $response->getHeader('Location');
+        if (($badParameter = strstr($uri, 'retour=http://')) === false) {
+            return;
+        }
+
+        $response->setHeader('Location',  str_replace($badParameter, urlencode($badParameter), $uri));
+    }
+}

--- a/spec/Authenticator/LoginFormAuthenticatorSpec.php
+++ b/spec/Authenticator/LoginFormAuthenticatorSpec.php
@@ -21,8 +21,8 @@ class LoginFormAuthenticatorSpec extends ObjectBehavior
             'usernameField' => 'username',
             'passwordField' => 'password',
             'extraFields' => [
-                'action' => 'login',
-                'foo' => 'bar',
+                'action=login',
+                'foo=bar'
             ],
             'username' => 'johndoe',
             'password' => 'unkn0wn',

--- a/spec/Authenticator/LoginFormAuthenticatorSpec.php
+++ b/spec/Authenticator/LoginFormAuthenticatorSpec.php
@@ -16,13 +16,13 @@ class LoginFormAuthenticatorSpec extends ObjectBehavior
     public function let($siteConfig)
     {
         $siteConfig = new SiteConfig([
-        'host' => 'example.com',
+            'host' => 'example.com',
             'loginUri' => 'http://example.com/login',
             'usernameField' => 'username',
             'passwordField' => 'password',
             'extraFields' => [
-                'action=login',
-                'foo=bar',
+                'action' => 'login',
+                'foo' => 'bar',
             ],
             'username' => 'johndoe',
             'password' => 'unkn0wn',

--- a/spec/Authenticator/LoginFormAuthenticatorSpec.php
+++ b/spec/Authenticator/LoginFormAuthenticatorSpec.php
@@ -22,7 +22,7 @@ class LoginFormAuthenticatorSpec extends ObjectBehavior
             'passwordField' => 'password',
             'extraFields' => [
                 'action=login',
-                'foo=bar'
+                'foo=bar',
             ],
             'username' => 'johndoe',
             'password' => 'unkn0wn',

--- a/spec/ExpressionLanguage/AuthenticatorProviderSpec.php
+++ b/spec/ExpressionLanguage/AuthenticatorProviderSpec.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace BD\GuzzleSiteAuthenticator\spec\ExpressionLanguage;
+
+class AuthenticatorProviderSpec
+{
+
+}

--- a/spec/ExpressionLanguage/AuthenticatorProviderSpec.php
+++ b/spec/ExpressionLanguage/AuthenticatorProviderSpec.php
@@ -4,9 +4,8 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace BD\GuzzleSiteAuthenticator\spec\ExpressionLanguage;
+namespace spec\BD\GuzzleSiteAuthenticator\ExpressionLanguage;
 
 class AuthenticatorProviderSpec
 {
-
 }

--- a/spec/Guzzle/AuthenticatorSubscriberSpec.php
+++ b/spec/Guzzle/AuthenticatorSubscriberSpec.php
@@ -20,6 +20,7 @@ class AuthenticatorSubscriberSpec extends ObjectBehavior
     public function let(
         SiteConfigBuilder $siteConfigBuilder,
         SiteConfig $siteConfig,
+        Factory $authenticatorFactory,
         ClientInterface $guzzle,
         Emitter $emitter,
         BeforeEvent $beforeEvent,

--- a/spec/Guzzle/AuthenticatorSubscriberSpec.php
+++ b/spec/Guzzle/AuthenticatorSubscriberSpec.php
@@ -25,8 +25,7 @@ class AuthenticatorSubscriberSpec extends ObjectBehavior
         BeforeEvent $beforeEvent,
         CompleteEvent $completeEvent,
         RequestInterface $request,
-        ResponseInterface $response,
-        Factory $authenticatorFactory)
+        ResponseInterface $response)
     {
         $siteConfig->getHost()->willReturn('example.com');
         $siteConfigBuilder->buildForHost('example.com')->willReturn($siteConfig);

--- a/spec/Guzzle/FixupMondeDiplomatiqueUriSubscriberSpec.php
+++ b/spec/Guzzle/FixupMondeDiplomatiqueUriSubscriberSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace spec\BD\GuzzleSiteAuthenticator\Guzzle;
+
+use BD\GuzzleSiteAuthenticator\Authenticator\Authenticator;
+use BD\GuzzleSiteAuthenticator\Authenticator\Factory;
+use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfig;
+use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfigBuilder;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Event\BeforeEvent;
+use GuzzleHttp\Event\CompleteEvent;
+use GuzzleHttp\Event\Emitter;
+use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Message\ResponseInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class FixupMondeDiplomatiqueUriSubscriberSpec extends ObjectBehavior
+{
+    function let(CompleteEvent $event, ResponseInterface $response)
+    {
+        $event->getResponse()->willReturn($response);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('BD\GuzzleSiteAuthenticator\Guzzle\FixupMondeDiplomatiqueUriSubscriber');
+    }
+
+    function it_registers_the_complete_request_event()
+    {
+        $this->getEvents()->shouldHaveKey('complete');
+    }
+
+    function it_ignores_responses_without_a_location_header(CompleteEvent $event, ResponseInterface $response)
+    {
+        $this->fixUri($event);
+    }
+
+    function it_encodes_the_unencoded_retour_parameter(CompleteEvent $event, ResponseInterface $response)
+    {
+        $response->hasHeader('Location')->willReturn(true);
+        $response->getHeader('Location')->willReturn('http://example.com/?foo=bar&retour=http://example.com');
+
+        $response->setHeader('Location', 'http://example.com/?foo=bar&retour%3Dhttp%3A%2F%2Fexample.com')->shouldBeCalled();
+
+        $this->fixUri($event);
+    }
+}

--- a/spec/Guzzle/FixupMondeDiplomatiqueUriSubscriberSpec.php
+++ b/spec/Guzzle/FixupMondeDiplomatiqueUriSubscriberSpec.php
@@ -2,43 +2,33 @@
 
 namespace spec\BD\GuzzleSiteAuthenticator\Guzzle;
 
-use BD\GuzzleSiteAuthenticator\Authenticator\Authenticator;
-use BD\GuzzleSiteAuthenticator\Authenticator\Factory;
-use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfig;
-use BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfigBuilder;
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Event\CompleteEvent;
-use GuzzleHttp\Event\Emitter;
-use GuzzleHttp\Message\RequestInterface;
-use GuzzleHttp\Message\Response;
 use GuzzleHttp\Message\ResponseInterface;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class FixupMondeDiplomatiqueUriSubscriberSpec extends ObjectBehavior
 {
-    function let(CompleteEvent $event, ResponseInterface $response)
+    public function let(CompleteEvent $event, ResponseInterface $response)
     {
         $event->getResponse()->willReturn($response);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType('BD\GuzzleSiteAuthenticator\Guzzle\FixupMondeDiplomatiqueUriSubscriber');
     }
 
-    function it_registers_the_complete_request_event()
+    public function it_registers_the_complete_request_event()
     {
         $this->getEvents()->shouldHaveKey('complete');
     }
 
-    function it_ignores_responses_without_a_location_header(CompleteEvent $event, ResponseInterface $response)
+    public function it_ignores_responses_without_a_location_header(CompleteEvent $event, ResponseInterface $response)
     {
         $this->fixUri($event);
     }
 
-    function it_encodes_the_unencoded_retour_parameter(CompleteEvent $event, ResponseInterface $response)
+    public function it_encodes_the_unencoded_retour_parameter(CompleteEvent $event, ResponseInterface $response)
     {
         $response->hasHeader('Location')->willReturn(true);
         $response->getHeader('Location')->willReturn('http://example.com/?foo=bar&retour=http://example.com');


### PR DESCRIPTION
> Requires https://github.com/wallabag/wallabag/pull/2751

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes (parsing of key/value)
| Deprecations? | no
| Tests pass?   | yes
| Documentation | yes
| Translation   | no
| Fixed tickets | fix https://github.com/wallabag/guzzle-site-authenticator/issues/12
| License       | MIT

This pull-request adds support for more complex login workflows. For instance, it can fetch a hidden field's value from an URI, and add it to the login request.

### Allow key/value pairs in `login_extra_fields`
With this change, the values are interpreted by the authenticator as being a key/value tupple separated by '=':

```
login_extra_fields: some_field=some_value
```

### Added ExpressionLanguage support to `login_extra_fields`

In addition, extra operations are possible using expression engine code:

```
login_extra_fields: hash=@=xpath("//form//input[@name='hash']", request_html(config.getLoginUri()))
```

This will fetch the html of the login URI (`request_html(config.getLoginUri())`), and return the first element matching a given xpath query (`xpath("//form//input[@name='hash']", <The HTML>`).

It allows handling of forms where a hash from the login form must be provided to the login request.

It has been tested and works with http://monde-diplomatique.fr, with this configuration:
```
title://h1[@class="h1"]
body: //div[@class="contenu-principal"]/div[@class="texte"]

requires_login: yes

login_uri: https://lecteurs.mondediplo.net/?page=connexion
login_username_field: email
login_password_field: mot_de_passe

login_extra_fields: page=connexion
login_extra_fields: formulaire_action=identification_lecteur
login_extra_fields: formulaire_action_args=@=xpath("//form//input[@name='formulaire_action_args']", request_html(config.getLoginUri()))
login_extra_fields: retour=http://www.monde-diplomatique.fr/
login_extra_fields: site_distant=http://www.monde-diplomatique.fr/
login_extra_fields: valider=valider

not_logged_in_xpath: //div[@id="paywall"]

test_url:
```

## TODO
- [x] Send a pull-request to @j0k3r's config package
- [x] Tests
- [ ] Extract the monde-diplomatique.fr fix