### PR TITLE
Siteconfigbuilder false by default

### DIFF
--- a/lib/Authenticator/LoginFormAuthenticator.php
+++ b/lib/Authenticator/LoginFormAuthenticator.php
@@ -22,6 +22,9 @@ class LoginFormAuthenticator implements Authenticator
         $this->siteConfig = $siteConfig;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function login(ClientInterface $guzzle)
     {
         $postFields = [
@@ -37,6 +40,9 @@ class LoginFormAuthenticator implements Authenticator
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isLoggedIn(ClientInterface $guzzle)
     {
         if (($cookieJar = $guzzle->getDefaultOption('cookies')) instanceof CookieJar) {
@@ -53,11 +59,7 @@ class LoginFormAuthenticator implements Authenticator
     }
 
     /**
-     * Checks from the HTML of a page if authentication is requested by a grabbed page.
-     *
-     * @param string $html
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isLoginRequired($html)
     {

--- a/lib/ExpressionLanguage/AuthenticatorProvider.php
+++ b/lib/ExpressionLanguage/AuthenticatorProvider.php
@@ -19,6 +19,9 @@ class AuthenticatorProvider implements ExpressionFunctionProviderInterface
         $this->guzzle = $guzzle;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getFunctions()
     {
         return [

--- a/lib/Guzzle/AuthenticatorSubscriber.php
+++ b/lib/Guzzle/AuthenticatorSubscriber.php
@@ -49,6 +49,9 @@ class AuthenticatorSubscriber implements SubscriberInterface, LoggerAwareInterfa
         $this->logger = $logger;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getEvents()
     {
         return [

--- a/lib/Guzzle/FixupMondeDiplomatiqueUriSubscriber.php
+++ b/lib/Guzzle/FixupMondeDiplomatiqueUriSubscriber.php
@@ -13,6 +13,9 @@ use GuzzleHttp\Event\SubscriberInterface;
  */
 class FixupMondeDiplomatiqueUriSubscriber implements SubscriberInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     public function getEvents()
     {
         return ['complete' => [['fixUri', 500]]];

--- a/lib/SiteConfig/ArraySiteConfigBuilder.php
+++ b/lib/SiteConfig/ArraySiteConfigBuilder.php
@@ -25,13 +25,7 @@ class ArraySiteConfigBuilder implements SiteConfigBuilder
     }
 
     /**
-     * Builds the SiteConfig for a host.
-     *
-     * @param $host
-     *
-     * @throws \OutOfRangeException If there is no config for $host
-     *
-     * @return SiteConfig
+     * {@inheritdoc}
      */
     public function buildForHost($host)
     {

--- a/lib/SiteConfig/ArraySiteConfigBuilder.php
+++ b/lib/SiteConfig/ArraySiteConfigBuilder.php
@@ -12,16 +12,12 @@ class ArraySiteConfigBuilder implements SiteConfigBuilder
      */
     private $configs = [];
 
-    private $defaultConfig;
-
     public function __construct(array $hostConfigMap = [])
     {
         foreach ($hostConfigMap as $host => $hostConfig) {
             $hostConfig['host'] = $host;
             $this->configs[$host] = new SiteConfig($hostConfig);
         }
-
-        $this->defaultConfig = new SiteConfig([]);
     }
 
     /**
@@ -30,13 +26,15 @@ class ArraySiteConfigBuilder implements SiteConfigBuilder
     public function buildForHost($host)
     {
         $host = strtolower($host);
+
         if (substr($host, 0, 4) === 'www.') {
             $host = substr($host, 4);
         }
+
         if (isset($this->configs[$host])) {
             return $this->configs[$host];
         }
 
-        return $this->defaultConfig;
+        return false;
     }
 }

--- a/lib/SiteConfig/SiteConfigBuilder.php
+++ b/lib/SiteConfig/SiteConfigBuilder.php
@@ -14,7 +14,7 @@ interface SiteConfigBuilder
      *
      * @throws \OutOfRangeException If there is no config for $host
      *
-     * @return SiteConfig
+     * @return SiteConfig|false
      */
     public function buildForHost($host);
 }

--- a/spec/SiteConfig/ArraySiteConfigBuilderSpec.php
+++ b/spec/SiteConfig/ArraySiteConfigBuilderSpec.php
@@ -22,8 +22,8 @@ class ArraySiteConfigBuilderSpec extends ObjectBehavior
         $this->buildForHost('example.com')->shouldReturnAnInstanceOf('BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfig');
     }
 
-    public function it_returns_the_default_config_on_a_host_that_does_not_exist()
+    public function it_returns_false_on_a_host_that_does_not_exist()
     {
-        $this->buildForHost('anotherexample.com')->shouldReturnAnInstanceOf('BD\GuzzleSiteAuthenticator\SiteConfig\SiteConfig');
+        $this->buildForHost('anotherexample.com')->shouldReturn(false);
     }
 }


### PR DESCRIPTION
In the `AuthenticatorSubscriber` we check for the siteconfig to be false OR not requires login.
So the SiteConfigBuilder can return false when it didn't found a SiteConfig for the given host.