### PR TITLE
Add a subscriber to redirect pages to abonnes.lemonde.fr when a user session is active

### DIFF
--- a/bundle/DependencyInjection/CompilerPass/RegisterWallabagGuzzleSubscribersPass.php
+++ b/bundle/DependencyInjection/CompilerPass/RegisterWallabagGuzzleSubscribersPass.php
@@ -25,5 +25,10 @@ class RegisterWallabagGuzzleSubscribersPass implements CompilerPassInterface
                 new Reference('bd_guzzle_site_authenticator.monde_diplomatique_uri_fix_subscriber'),
             ]
         );
+        $definition->addMethodCall(
+            'addSubscriber', [
+                new Reference('bd_guzzle_site_authenticator.lemonde_redirect_subscriber'),
+            ]
+        );
     }
 }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -21,3 +21,6 @@ services:
 
     bd_guzzle_site_authenticator.monde_diplomatique_uri_fix_subscriber:
         class: BD\GuzzleSiteAuthenticator\Guzzle\FixupMondeDiplomatiqueUriSubscriber
+
+    bd_guzzle_site_authenticator.lemonde_redirect_subscriber:
+        class: BD\GuzzleSiteAuthenticator\Guzzle\RedirectLemondeSubscriber

--- a/lib/Guzzle/RedirectLemondeSubscriber.php
+++ b/lib/Guzzle/RedirectLemondeSubscriber.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace BD\GuzzleSiteAuthenticator\Guzzle;
+
+use GuzzleHttp\Event\BeforeEvent;
+use GuzzleHttp\Event\RequestEvents;
+use GuzzleHttp\Event\SubscriberInterface;
+
+/**
+ * Redirect lemonde.fr links when authentication is present
+ */
+class RedirectLemondeSubscriber implements SubscriberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getEvents()
+    {
+        return ['before' => [['rewriteURL', RequestEvents::REDIRECT_RESPONSE]]];
+    }
+
+    public function rewriteURL(BeforeEvent $event)
+    {
+        $request = $event->getRequest();
+        $url = parse_url($request->getUrl());
+        $cookie = $request->getHeader('cookie');
+
+        if ($url['host'] == 'www.lemonde.fr' && !empty($cookie))
+        {
+            $request->setHost('abonnes.lemonde.fr');
+        }
+    }
+}


### PR DESCRIPTION
This PR provides a way to redirect Graby to abonnes.lemonde.fr when requesting www.lemonde.fr pages and cookie is not empty (_in this case: user is logged_).

This PR depends on another PR to ftr-site-config in order to provide credential support for lemonde.fr.

[ ] Handle/check mobile links
[ ] Add specs