### PR TITLE
Fix exception when HTTP response has no body, e.g. 30x redirects

### DIFF
--- a/lib/Guzzle/AuthenticatorSubscriber.php
+++ b/lib/Guzzle/AuthenticatorSubscriber.php
@@ -88,8 +88,19 @@ class AuthenticatorSubscriber implements SubscriberInterface, LoggerAwareInterfa
             return;
         }
 
+        $body = $event->getResponse()->getBody();
+
+        if (
+            null === $body
+            || '' === $body->getContents()
+        ) {
+            $this->logger->debug('loginIfRequested> empty body, ignoring');
+
+            return;
+        }
+
         $authenticator = $this->authenticatorFactory->buildFromSiteConfig($config);
-        $isLoginRequired = $authenticator->isLoginRequired($event->getResponse()->getBody());
+        $isLoginRequired = $authenticator->isLoginRequired($body);
 
         $this->logger->debug('loginIfRequested> retry #' . self::$retries . ' with login ' . ($isLoginRequired ? '' : 'not ') . 'required');
 


### PR DESCRIPTION
An exception is thrown when the HTTP response have an empty body, crashing wallabag's fetching mechanism.

Example with this page:  https://www.lemonde.fr/international/live/2022/02/25/guerre-en-ukraine-l-offensive-russe-entre-dans-sa-deuxieme-journee-des-explosions-entendues-a-kiev_6115172_3210.html